### PR TITLE
docs: correct the installation remote repository url

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,5 +22,5 @@ mv ~/.config/kitty ~/.config/kitty.old
 Clone this repo to ~/.config/kitty/
 
 ```bash
-git clone https://github.dev/KevenGoncalves/kitty-dotfiles ~/.config/kitty/
+git clone https://github.com/KevenGoncalves/kitty-dotfiles ~/.config/kitty/
 ```


### PR DESCRIPTION
## Description

This PR fixes a misspelling error on the link of the repository on the installation section

## Screenshots

![image](https://github.com/KevenGoncalves/kitty-dotfiles/assets/56705157/20d997b5-5ef9-447f-8fc2-b4c0b69eb988)

Just replaced `.dev` by `.com` and voila

![image](https://github.com/KevenGoncalves/kitty-dotfiles/assets/56705157/d5ce4aea-b88d-4167-9828-47e2e91847db)
